### PR TITLE
2 implement git hub info command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ deps:			## Install package dependencies
 	go get -u github.com/spf13/cobra/cobra
 	go get -u golang.org/x/oauth2
 	go get -u gopkg.in/src-d/go-git.v4/...
-	go get -u github.com/google/go-github
+	go get -u github.com/google/go-github/github
 	
 dev-deps:		## Install dev dependencies
 	go get -u github.com/mattn/goveralls

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ lint:			## Lint source code
 deps:			## Install package dependencies
 	go get -u github.com/spf13/cobra/cobra
 	go get -u golang.org/x/oauth2
+	go get -u gopkg.in/src-d/go-git.v4/...
+	go get -u github.com/google/go-github
 	
 dev-deps:		## Install dev dependencies
 	go get -u github.com/mattn/goveralls

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -15,23 +15,22 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-package main
+package cmd
 
 import (
-	hub "github.com/repejota/git-hub"
-	"github.com/repejota/git-hub/cmd"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
 )
 
-var (
-	// Version is the current version number
-	Version string
-	// Build is the current build id
-	Build string
-)
-
-func main() {
-	cmd.RootCmd.SetVersionTemplate(`{{with .Name}}{{printf "%s " .}}{{end}}{{printf "%s" .Version}}`)
-	cmd.RootCmd.Version = hub.ShowVersionInfo(Version, Build)
-	cmd.RootCmd.AddCommand(cmd.InfoCmd)
-	cmd.Execute()
+// InfoCmd represents the info command
+var InfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Get information about the repository",
+	Long:  `Get information about the repository and its github project`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("info command")
+		os.Exit(0)
+	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,9 +26,9 @@ import (
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "git hub",
+	Use:   "git-hub",
 	Short: "Automate git and github",
-	Long:  `git hub automates git and github flow of work`,
+	Long:  `git-hub automates git and github flow of work`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		os.Exit(0)


### PR DESCRIPTION
## Description

Implements `git hub info` and shows:
* GitHub repository ID
* GitHub repository Full Name ( organization/repository format )
* GitHub repository html URL